### PR TITLE
Hide English Definitions

### DIFF
--- a/app/src/components/Book.vue
+++ b/app/src/components/Book.vue
@@ -14,7 +14,7 @@
                 <a class='hiragana' @click='playVoice(item.word)'>{{ item.hiragana || item.word }}</a>
                 <span class='romaji' :class='{ show: showRomaji }'>{{ item.romaji }}</span>
               </p>
-              <p class='meaning'>{{ item.meaning }}</p>
+              <span class='meaning' :class='{ show: showMeaning }'>{{ item.meaning }}</span>
               <button class='btn-del' @click='unhide(item)'>×</button>
             </div>
           </li>
@@ -45,6 +45,9 @@ export default {
   computed: {
     showRomaji () {
       return this.store.settings.showRomaji
+    },
+    showMeaning () {
+      return this.store.settings.showMeaning
     },
     hiddenCards () {
       const { hides, words } = this.store
@@ -154,7 +157,12 @@ export default {
     }
   }
   .meaning {
+    opacity: 0;
+    transition: opacity .3s;
     margin: .5em 0 0;
+    &.show {
+      opacity: 1;
+    }
   }
   .btn-del {
     position: absolute;

--- a/app/src/components/Card.vue
+++ b/app/src/components/Card.vue
@@ -8,7 +8,9 @@
     <h1 class='word'>
       <a :href='searchUrl' target='_blank'>{{card.word}}</a>
     </h1>
-    <p class='meaning'>{{card.meaning}}</p>
+    <div class='meaning' :class='{ show: showMeaning }'>
+      {{card.meaning}}
+    </div>
     <span class='level'>N{{card.level}}</span>
     <Voice :word='card.word' ref='voiceRef' />
   </div>
@@ -31,6 +33,9 @@ export default {
   computed: {
     showRomaji () {
       return bus.store.settings.showRomaji
+    },
+    showMeaning () {
+      return bus.store.settings.showMeaning
     },
     card () {
       return this.store.card
@@ -80,9 +85,14 @@ export default {
     margin: .5em 0;
   }
   .meaning {
+    opacity: 0;
     max-width: 80%;
     margin: 1em auto;
     font-weight: 300;
+    transition: opacity .3s;
+    &.show {
+      opacity: 1;
+    }
   }
   .level {
     display: inline-block;

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -19,6 +19,12 @@
       帳
     </button>
     <button
+      :class='{ btn: true, show: store.showBook }'
+      @click='toggleMeaning'
+    >
+      英
+    </button>
+    <button
       class='btn'
       @click='changeTheme'
     >
@@ -53,6 +59,7 @@ export default {
     },
     changeLevel: bus.changeLevel,
     toggleBook: bus.toggleBook,
+    toggleMeaning: bus.toggleMeaning,
     changeTheme: bus.changeTheme
   }
 }

--- a/app/src/utils/bus.js
+++ b/app/src/utils/bus.js
@@ -72,6 +72,10 @@ const bus = new Vue({
       this.store.settings.showRomaji = !this.store.settings.showRomaji
       local.update(this.store)
     },
+    toggleMeaning () {
+      this.store.settings.showMeaning = !this.store.settings.showMeaning
+      local.update(this.store)
+    },
     toggleFontSize () {
       this.store.settings.fontSize = getNextArrEl(this.store.settings.fontSize, FONT_SIZES)
       local.update(this.store)

--- a/app/src/utils/local.js
+++ b/app/src/utils/local.js
@@ -18,6 +18,7 @@ export const initStore = {
   hides: [],
   settings: {
     showRomaji: false,
+    showMeaning: true,
     fontSize: 'm', // 's, m, l'
     theme: 'sunrise' // 'sunrise', 'sunset', 'moon'
   }


### PR DESCRIPTION
-- Added a toggle in the toolbar that hides the English meaning within the card and also within the book
-- Right now it's in the toolbar as "英" between "帳" and color scheme

This is based on a suggestion made here: https://github.com/wkei/the-tab-of-words/issues/9 (also I find it useful too, cause it can act like a flashcard)